### PR TITLE
Update virtuoso to 7.2.6.1 and Alpine to 3.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM alpine:3.8 AS builder
+FROM alpine:3.14 AS builder
 MAINTAINER Xavier Garnier 'xavier.garnier@irisa.fr'
 
 # Environment variables
 ENV VIRTUOSO_GIT_URL https://github.com/openlink/virtuoso-opensource.git
 ENV VIRTUOSO_DIR /virtuoso-opensource
-ENV VIRTUOSO_GIT_VERSION 7.2.5.1
+ENV VIRTUOSO_GIT_VERSION 7.2.6.1
 
 # Install prerequisites, Download, Patch, compile and install
 RUN apk add --update git automake autoconf automake libtool bison flex gawk gperf openssl g++ openssl-dev make && \
@@ -19,7 +19,7 @@ RUN apk add --update git automake autoconf automake libtool bison flex gawk gper
 
 
 # Final image
-FROM alpine:3.8
+FROM alpine:3.14
 ENV PATH /usr/local/virtuoso-opensource/bin/:$PATH
 RUN apk add --no-cache openssl py-pip && \
     pip install crudini && \


### PR DESCRIPTION
Hello dear AskOmics team, 

A new version of Virtuoso has been released (7.2.6.1), here is an update of the `Dockerfile`. I took the occasion to update the Alpine base image to 3.14.

Kind regards,

X