### PR TITLE
WAIT_FOR_DATA

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Virtuoso dockerized, based on Alpine
 
 Based on [tenforce/docker-virtuoso](https://github.com/tenforce/docker-virtuoso) and [jplu/docker-virtuoso](https://github.com/jplu/docker-virtuoso).
 
-Image have the same functionalities than [tenforce/docker-virtuoso](https://github.com/tenforce/docker-virtuoso), but it is lighter (123MB instead of 496MB)
 
 ## Pull from DockerHub
 
@@ -61,6 +60,7 @@ environment variables when launch.
 
 ```bash
 docker run --name my-virtuoso \
+    --privileged \
     -p 8890:8890 -p 1111:1111 \
     -e DBA_PASSWORD=myDbaPassword \
     -e SPARQL_UPDATE=true \
@@ -74,6 +74,11 @@ docker run --name my-virtuoso \
 The S3 bucket is mounted on `/tmp/toLoadS3` folder.  After the RDF files have
 been imported, then the S3 folder is unmounted.  You can import RDF data from
 the S3 folder and the `toLoad` folder. Both are not exclusives.
+
+Mounting S3 bucket require the `--privileged` option.
+
+### `WAIT_LOADING_DATA`
+If the `WAIT_LOADING_DATA` environment variable is set to `true`, the virtuoso web interface will not be accessible until the data (S3 and /toLoad directory) will be loaded.
 
 ## Dumping your Virtuoso data as quads
 Enter the Virtuoso docker, open ISQL and execute the `dump_nquads` procedure. The dump will be available in `/my/path/to/the/virtuoso/db/dumps`.
@@ -95,6 +100,7 @@ docker exec -it my-virtuoso sh
 isql-v -U dba -P $DBA_PASSWORD
 SQL> ld_dir('dumps', '*.nq', 'http://foo.bar');
 SQL> rdf_loader_run();
+SQL> exec('checkpoint');
 ```
 
 Validate the `ll_state` of the load. If `ll_state` is 2, the load completed.

--- a/virtuoso.sh
+++ b/virtuoso.sh
@@ -21,12 +21,20 @@ do
   crudini --set /data/virtuoso.ini "$section" "$key" "$value"
 done
 
+# Create alternate config file for running virtuoso on another http port
+# during data loading (if WAIT_LOADING_DATA is true)
+cp /data/virtuoso.ini /tmp/virtuoso-dummy-http-port.ini
+crudini --set /tmp/virtuoso-dummy-http-port.ini "HTTPServer" "ServerPort" "7000"
+if [ "$WAIT_LOADING_DATA" = "true" ]; then CONFIG_FILE="/tmp/virtuoso-dummy-http-port.ini"; else CONFIG_FILE="/data/virtuoso.ini"; fi
+echo "Use $CONFIG_FILE to configure and load data"
+
+
 # Set dba password
 touch /sql-query.sql
 echo "Updating dba password and sparql update..."
 if [ "$DBA_PASSWORD" ]; then echo "user_set_password('dba', '$DBA_PASSWORD');" >> /sql-query.sql ; fi
-if [ "$SPARQL_UPDATE" = "true" ]; then echo "GRANT SPARQL_UPDATE to \"SPARQL\";" >> /sql-query.sql ; fi
-virtuoso-t +wait && isql-v -U dba -P dba < /virtuoso/dump_nquads_procedure.sql && isql-v -U dba -P dba < /sql-query.sql
+if [ "$SPARQL_UPDATE" = "true" ]; then echo 'GRANT SPARQL_UPDATE to "SPARQL";' >> /sql-query.sql ; fi
+virtuoso-t +configfile ${CONFIG_FILE} +wait && isql-v -U dba -P dba < /virtuoso/dump_nquads_procedure.sql && isql-v -U dba -P dba < /sql-query.sql
 kill $(ps ax | egrep '[v]irtuoso-t' | awk '{print $1}')
 
 # Make sure killing is done
@@ -34,22 +42,22 @@ sleep 2
 
 
 # Mount S3FS
-# only if $S3_SERVER_HOSTNAME is defined and /toLoad folder does not exists
 if [ "$S3_SERVER_URL" ];
 then
     mkdir -p $S3_LOAD_DIR
 
     # connect to S3 bucket
-    echo "$S3_ACCESS_KEY_ID:$S3_SECRET_ACCESS_KEY" > .passwd-s3fs
-    chmod 600 .passwd-s3fs
-    s3fs ${S3_BUCKET_NAME} $S3_LOAD_DIR -o passwd_file=.passwd-s3fs -o url=${S3_SERVER_URL} -o use_path_request_style -o allow_other
+    echo "$S3_ACCESS_KEY_ID:$S3_SECRET_ACCESS_KEY" > /tmp/.passwd-s3fs
+    chmod 600 /tmp/.passwd-s3fs
+    s3fs ${S3_BUCKET_NAME} $S3_LOAD_DIR -o passwd_file=/tmp/.passwd-s3fs -o url=${S3_SERVER_URL} -o use_path_request_style -o allow_other
 fi
 
 
 # Load data
 if [ -d "toLoad" ] || [ -d $S3_LOAD_DIR ] ;
 then
-    echo "Start data loading from toLoad folder..."
+    echo "Start data loading from toLoad/toLoadS3 folder..."
+    echo `date +%Y-%m-%dT%H:%M:%S%:z` > .data_loaded_start
     pwd="dba"
     graph="http://localhost:8890/DAV"
     if [ "$DBA_PASSWORD" ]; then pwd="$DBA_PASSWORD" ; fi
@@ -60,16 +68,19 @@ then
     echo "exec('checkpoint');" >> /load_data.sql
     echo "WAIT_FOR_CHILDREN; " >> /load_data.sql
     echo "$(cat /load_data.sql)"
-    virtuoso-t +wait && isql-v -U dba -P "$pwd" < /load_data.sql
+    virtuoso-t +configfile ${CONFIG_FILE} +wait && isql-v -U dba -P "$pwd" < /load_data.sql
     kill $(ps ax | egrep '[v]irtuoso-t' | awk '{print $1}')
-    echo `date +%Y-%m-%dT%H:%M:%S%:z` > .data_loaded
+    echo "Data loaded!"
+    echo `date +%Y-%m-%dT%H:%M:%S%:z` > .data_loaded_end
 fi
 
 # umount S3FS volume
 if [ -d $S3_LOAD_DIR ] ;
 then
+    echo "Unmount ${S3_LOAD_DIR}"
     umount $S3_LOAD_DIR
-    rm -r .passwd-s3fs $S3_LOAD_DIR
+    rm -r /tmp/.passwd-s3fs $S3_LOAD_DIR
 fi
 
+echo "Running virtuoso"
 exec virtuoso-t +wait +foreground

--- a/virtuoso.sh
+++ b/virtuoso.sh
@@ -34,6 +34,7 @@ touch /sql-query.sql
 echo "Updating dba password and sparql update..."
 if [ "$DBA_PASSWORD" ]; then echo "user_set_password('dba', '$DBA_PASSWORD');" >> /sql-query.sql ; fi
 if [ "$SPARQL_UPDATE" = "true" ]; then echo 'GRANT SPARQL_UPDATE to "SPARQL";' >> /sql-query.sql ; fi
+if [ "$SPARQL_UPDATE" = "true" ]; then echo 'GRANT execute on "DB.DBA.L_O_LOOK_NE" to "SPARQL";' >> /sql-query.sql ; fi
 virtuoso-t +configfile ${CONFIG_FILE} +wait && isql-v -U dba -P dba < /virtuoso/dump_nquads_procedure.sql && isql-v -U dba -P dba < /sql-query.sql
 kill $(ps ax | egrep '[v]irtuoso-t' | awk '{print $1}')
 


### PR DESCRIPTION
This PR add the following features:

- `WAIT_FOR_DATA` env

If the `WAIT_LOADING_DATA` environment variable is set to `true`, the virtuoso web interface will not be accessible until the data (S3 and /toLoad directory) will be loaded.

- fix SPARQL_UPDATE

add `GRANT execute on "DB.DBA.L_O_LOOK_NE" to "SPARQL";` to fix the update permission.
