### PR TITLE
Release 7.2.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,18 +18,21 @@ ENV VIRTUOSO_GIT_VERSION 7.2.9
 
 COPY patch.diff /patch.diff
 
-# Install prerequisites, Download, Patch, compile and install
+# Install prerequisites
 RUN apk add --update git automake autoconf automake libtool bison flex gawk gperf openssl \
-    g++ openssl-dev make patch xz-dev bzip2-dev && \
-    git clone -b v${VIRTUOSO_GIT_VERSION} --single-branch --depth=1 ${VIRTUOSO_GIT_URL} ${VIRTUOSO_DIR} && \
-    cd ${VIRTUOSO_DIR} && \
-    patch ${VIRTUOSO_DIR}/libsrc/Wi/sparql_io.sql < /patch.diff && \
-    ./autogen.sh && \
-    CFLAGS="-O2 -m64" && export CFLAGS && \
-    ./configure --disable-bpel-vad --enable-conductor-vad --enable-fct-vad --disable-dbpedia-vad --disable-demo-vad --disable-isparql-vad --disable-ods-vad --disable-sparqldemo-vad --disable-syncml-vad --disable-tutorial-vad --program-transform-name="s/isql/isql-v/" && \
-    make -j $(grep -c '^processor' /proc/cpuinfo) && \
-    make -j $(grep -c '^processor' /proc/cpuinfo) install
-
+    g++ openssl-dev make patch xz-dev bzip2-dev
+# Download sources
+RUN git clone -b v${VIRTUOSO_GIT_VERSION} --single-branch --depth=1 ${VIRTUOSO_GIT_URL} ${VIRTUOSO_DIR}
+WORKDIR ${VIRTUOSO_DIR}
+# Patch
+RUN patch ${VIRTUOSO_DIR}/libsrc/Wi/sparql_io.sql < /patch.diff
+# Complile
+RUN  ./autogen.sh
+RUN CFLAGS="-O2 -m64" && export CFLAGS && \
+    ./configure --disable-bpel-vad --enable-conductor-vad --enable-fct-vad --disable-dbpedia-vad --disable-demo-vad --disable-isparql-vad --disable-ods-vad --disable-sparqldemo-vad --disable-syncml-vad --disable-tutorial-vad --program-transform-name="s/isql/isql-v/"
+RUN make -j $(grep -c '^processor' /proc/cpuinfo)
+# Install
+RUN make -j $(grep -c '^processor' /proc/cpuinfo) install
 
 # Final image
 FROM alpine:3.17

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Compile s3fs in a separate image
-FROM alpine:3.16 AS s3fs-builder
+FROM alpine:3.17 AS s3fs-builder
 RUN apk add --update fuse fuse-dev automake gcc make libcurl curl-dev libxml2 libxml2-dev \
     openssl openssl-dev autoconf g++
 RUN wget https://github.com/s3fs-fuse/s3fs-fuse/archive/refs/tags/v1.91.zip && \
@@ -8,13 +8,13 @@ WORKDIR s3fs-fuse-1.91
 RUN ./autogen.sh && ./configure && make && make install
 
 # Compile virtuoso in a separate image
-FROM alpine:3.16 AS builder
+FROM alpine:3.17 AS builder
 MAINTAINER Xavier Garnier 'xavier.garnier@irisa.fr'
 
 # Environment variables
 ENV VIRTUOSO_GIT_URL https://github.com/openlink/virtuoso-opensource.git
 ENV VIRTUOSO_DIR /virtuoso-opensource
-ENV VIRTUOSO_GIT_VERSION 7.2.8
+ENV VIRTUOSO_GIT_VERSION 7.2.9
 
 COPY patch.diff /patch.diff
 
@@ -32,7 +32,7 @@ RUN apk add --update git automake autoconf automake libtool bison flex gawk gper
 
 
 # Final image
-FROM alpine:3.16
+FROM alpine:3.17
 ENV PATH /usr/local/virtuoso-opensource/bin/:$PATH
 COPY --from=s3fs-builder  /usr/local/bin/s3fs /usr/local/bin/s3fs
 


### PR DESCRIPTION
BONJOUR MR @mboudet 

HERE IZ A PR TO UPGRADE VIRTUOSO TO 7.2.9.

ITS ALSO IMPROVE :
- multiple layer on the build stage to build the image faster with buildkit (parallèle execution of build step)
- upgarde base alpine to 3.17