### PR TITLE
ci(docker-publish): don't build on arm/v7

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -50,7 +50,7 @@ jobs:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           labels: ${{ steps.meta.outputs.labels }}
           secrets: |
             GIT_AUTH_TOKEN=${{ secrets.DOCKER_REGISTRY_TOKEN }}


### PR DESCRIPTION
The current version of Virtuoso Open Source Edition (Column Store) can only be built on 64bit platforms